### PR TITLE
Correct gas cost for 'log' instruction in README

### DIFF
--- a/traces/README.md
+++ b/traces/README.md
@@ -23,7 +23,7 @@ The gas cost for a single instruction is set to **$1$**
 
 All host calls have a gas cost of **$10$**, with the following exceptions:
 - **`transfer`**: Gas cost is set to **$10 + \omega_9$**, as specified in the GP.
-- **`log`**: Gas cost is set to **0**, as defined in [JIP-1](https://hackmd.io/@polkadot/jip1).
+- **`log`**: Gas cost is set to **10**, as defined in [JIP-1](https://github.com/polkadot-fellows/JIPs/blob/main/JIP-1.md).
 
 ## Vectors
 


### PR DESCRIPTION
Updated gas cost for 'log' instruction from 0 to 10 as per JIP-1. The sentence is a bit weird, since it's not really an exception (given all other host calls have 10 as well), but I thought it makes sense to state that explictly for **log**.